### PR TITLE
Add option to hide quick access button

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -326,6 +326,8 @@ pub struct UserConfig {
     pub close_on_escape: bool,
     #[serde(default)]
     pub copy_with_event_name: bool,
+    #[serde(default = "default_true")]
+    pub show_quick_access_icon: bool,
 
     // === Time Ruler Settings ===
     #[serde(default)]
@@ -442,6 +444,8 @@ impl Default for UserConfig {
             label_column_category_color: [0.8, 0.8, 0.2, 1.0],
             close_on_escape: true,
             copy_with_event_name: false,
+            show_quick_access_icon: true,
+
             time_ruler_interval: TimeRulerInterval::default(),
             time_ruler_show_current_time: false,
             tracked_events: HashSet::new(),
@@ -489,6 +493,7 @@ pub struct RuntimeConfig {
     pub label_column_category_color: [f32; 4],
     pub close_on_escape: bool,
     pub copy_with_event_name: bool,
+    pub show_quick_access_icon: bool,
 
     // === Time Ruler Settings ===
     pub time_ruler_interval: TimeRulerInterval,
@@ -538,6 +543,8 @@ impl Default for RuntimeConfig {
             label_column_category_color: [0.8, 0.8, 0.2, 1.0],
             close_on_escape: true,
             copy_with_event_name: false,
+            show_quick_access_icon: true,
+
             time_ruler_interval: TimeRulerInterval::default(),
             time_ruler_show_current_time: false,
             tracked_events: HashSet::new(),
@@ -621,6 +628,8 @@ pub fn apply_user_overrides() {
                 user_cfg.label_column_category_color,
                 user_cfg.close_on_escape,
                 user_cfg.copy_with_event_name,
+                user_cfg.show_quick_access_icon,
+
                 user_cfg.time_ruler_interval,
                 user_cfg.time_ruler_show_current_time,
                 user_cfg.tracked_events.clone(),
@@ -692,6 +701,8 @@ pub fn apply_user_overrides() {
         runtime.label_column_category_color = user_settings.30;
         runtime.close_on_escape = user_settings.31;
         runtime.copy_with_event_name = user_settings.32;
+        runtime.show_quick_access_icon = user_settings.38;
+
         runtime.time_ruler_interval = user_settings.33;
         runtime.time_ruler_show_current_time = user_settings.34;
         runtime.tracked_events = user_settings.35;
@@ -774,6 +785,8 @@ pub fn extract_user_overrides() {
     user_cfg.label_column_category_color = runtime.label_column_category_color;
     user_cfg.close_on_escape = runtime.close_on_escape;
     user_cfg.copy_with_event_name = runtime.copy_with_event_name;
+    user_cfg.show_quick_access_icon = runtime.show_quick_access_icon;
+
     user_cfg.time_ruler_interval = runtime.time_ruler_interval;
     user_cfg.time_ruler_show_current_time = runtime.time_ruler_show_current_time;
     user_cfg.category_visibility = runtime.category_visibility.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,9 +65,10 @@ fn load() {
     check_for_event_tracks_update();
     
     // Setup Quick Access icon
-    if (settings.show_quick_access_icon)
+    if (settings.show_quick_access_icon) {
         setup_quick_access();
-    
+    }
+
     register_keybind_with_string("Toggle Event Timers", toggle_window_keybind, "ALT+E")
         .revert_on_unload();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,8 @@ fn load() {
     check_for_event_tracks_update();
     
     // Setup Quick Access icon
-    setup_quick_access();
+    if (settings.show_quick_access_icon)
+        setup_quick_access();
     
     register_keybind_with_string("Toggle Event Timers", toggle_window_keybind, "ALT+E")
         .revert_on_unload();

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -241,6 +241,7 @@ pub fn render_settings(ui: &Ui) {
         ui.text("Other");
         ui.checkbox("Close window with ESC", &mut config.close_on_escape);
         ui.checkbox("Include event name when copying waypoint", &mut config.copy_with_event_name);
+        ui.checkbox("Show quick access icon", &mut config.show_quick_access_icon);
 
         ui.unindent();
     }


### PR DESCRIPTION
Hi, i wanted the option to disable the quick access button.

The changes are only to add the option in the options menu inside Nexus ( in Main Window > Others) and a conditional in lib when loading the icon that checks this option.

I couldn't get the build bat script to work, something about missing link.exe, i lack the knowledge, so i couldn't test.
The change is quite simple so it should be a-ok.

Also i don't know how to make it update after toggling the option. Saw there's a remove_quick_access() in quick_access.rs, but i'm unsure of where to put it.