### PR TITLE
Add Nix dev environment for building the DLL from Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ target/
 #.idea/
 /.claude
 NUL
+
+# Nix dev shell artifacts
+/.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,66 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1782900513,
+        "narHash": "sha256-GHrsl1+ysDFgmDQtQSqWS7TiYD2Q58VlwLvnf1+crJM=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "16810aa8f4ad89ca480b1513774e8b6f485fe368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782959384,
+        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782864348,
+        "narHash": "sha256-NVYhLbaefeIUftPlo3kS6qr0xd8eFJRodEiaHrvFKR4=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "0d381ca097a8e0375a19387874d952c0a230ac4f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,56 @@
+{
+  description = "Dev environment for event-timers (GW2 Nexus addon, x86_64-pc-windows-gnu)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, fenix }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      mingw = pkgs.pkgsCross.mingwW64;
+
+      # Stable Rust for the host (native `cargo test` on nexus-free crates)
+      # plus the std library for the Windows target (the addon dll itself).
+      # Explicit component list: defaultToolchain would pull in rust-docs (~1GB).
+      toolchain = fenix.packages.${system}.combine [
+        (fenix.packages.${system}.stable.withComponents [
+          "cargo"
+          "clippy"
+          "rustc"
+          "rustfmt"
+          "rust-std"
+        ])
+        fenix.packages.${system}.targets.x86_64-pc-windows-gnu.stable.rust-std
+      ];
+    in
+    {
+      devShells.${system}.default = pkgs.mkShell {
+        packages = [
+          toolchain
+          mingw.stdenv.cc
+        ];
+
+        # The addon only compiles for the Windows target (nexus pulls in
+        # windows-only crates). Tests live in nexus-free workspace crates and
+        # run natively, so the default target stays the host; build the dll
+        # with `cargo build --target x86_64-pc-windows-gnu`.
+        CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER = "x86_64-w64-mingw32-gcc";
+        # mingw pthreads is not on the cross-gcc's default search path in nix.
+        CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS =
+          "-L native=${mingw.windows.pthreads}/lib";
+
+        # mkShell exports host CC/CXX, which the `cc` crate can pick up and
+        # silently produce ELF objects (arcdps-imgui-sys). Target-scoped vars
+        # take precedence and force the cross compilers.
+        CC_x86_64_pc_windows_gnu = "x86_64-w64-mingw32-gcc";
+        CXX_x86_64_pc_windows_gnu = "x86_64-w64-mingw32-g++";
+        AR_x86_64_pc_windows_gnu = "x86_64-w64-mingw32-ar";
+      };
+    };
+}


### PR DESCRIPTION
Adds a Nix flake with a pinned Rust + mingw-w64 cross toolchain so the addon DLL can be built from Linux with `cargo build --target x86_64-pc-windows-gnu`.

Notes:
- The CC/CXX/AR overrides are target-scoped on purpose: without them, `cc`-crate build scripts pick up the host compiler and quietly emit ELF objects into the PE link (surfaces as hundreds of undefined imgui symbols).
- No changes to any Rust code or to the normal Windows build; it's opt-in tooling for anyone on Linux/Nix.

This is the first of a stack of four PRs (followed by the core-crate extraction, defaults consolidation, and settings unification refactors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)